### PR TITLE
Ensure remove weight norm actually removes the weight computation from the inference network

### DIFF
--- a/glow.py
+++ b/glow.py
@@ -281,15 +281,15 @@ class WaveGlow(torch.nn.Module):
         audio = audio.permute(0,2,1).contiguous().view(audio.size(0), -1).data
         return audio
 
-    def remove_weightnorm(self):
-        waveglow = copy.deepcopy(self)
-        for WN in waveglow.WN:
-            WN.start = torch.nn.utils.remove_weight_norm(WN.start)
-            WN.in_layers = remove(WN.in_layers)
-            WN.cond_layers = remove(WN.cond_layers)
-            WN.res_layers = remove(WN.res_layers)
-            WN.skip_layers = remove(WN.skip_layers)
-        self = waveglow
+def remove_weightnorm(self):
+    waveglow = copy.deepcopy(self)
+    for WN in waveglow.WN:
+        WN.start = torch.nn.utils.remove_weight_norm(WN.start)
+        WN.in_layers = remove(WN.in_layers)
+        WN.cond_layers = remove(WN.cond_layers)
+        WN.res_layers = remove(WN.res_layers)
+        WN.skip_layers = remove(WN.skip_layers)
+    return waveglow
 
 def remove(conv_list):
     new_conv_list = torch.nn.ModuleList()

--- a/inference.py
+++ b/inference.py
@@ -29,11 +29,12 @@ import numpy as np
 from scipy.io.wavfile import write
 import torch
 from mel2samp import files_to_list, MAX_WAV_VALUE
+from glow import remove_weightnorm
 
 def main(mel_files, waveglow_path, sigma, output_dir, sampling_rate, is_fp16):
     mel_files = files_to_list(mel_files)
     waveglow = torch.load(waveglow_path)['model']
-    waveglow.remove_weightnorm()
+    waveglow = remove_weightnorm(waveglow)
     waveglow.cuda().eval()
     if is_fp16:
         waveglow.half()


### PR DESCRIPTION
The remove_weightnorm function in the WaveGlow does not seem to work. It does not remove the weight_norm computation from the network when performing inference (observed through pytorch profiler). This pull request is a quick hack to make it work. Inference performance should increase by 5-10%.

