### PR TITLE
Resolve PyTorch deprecation warnings

### DIFF
--- a/glow.py
+++ b/glow.py
@@ -34,8 +34,8 @@ import torch.nn.functional as F
 def fused_add_tanh_sigmoid_multiply(input_a, input_b, n_channels):
     n_channels_int = n_channels[0]
     in_act = input_a+input_b
-    t_act = torch.nn.functional.tanh(in_act[:, :n_channels_int, :])
-    s_act = torch.nn.functional.sigmoid(in_act[:, n_channels_int:, :])
+    t_act = torch.tanh(in_act[:, :n_channels_int, :])
+    s_act = torch.sigmoid(in_act[:, n_channels_int:, :])
     acts = t_act * s_act
     return acts
 

--- a/glow_old.py
+++ b/glow_old.py
@@ -7,8 +7,8 @@ from glow import Invertible1x1Conv, remove
 def fused_add_tanh_sigmoid_multiply(input_a, input_b, n_channels):
     n_channels_int = n_channels[0]
     in_act = input_a+input_b
-    t_act = torch.nn.functional.tanh(in_act[:, :n_channels_int, :])
-    s_act = torch.nn.functional.sigmoid(in_act[:, n_channels_int:, :])
+    t_act = torch.tanh(in_act[:, :n_channels_int, :])
+    s_act = torch.sigmoid(in_act[:, n_channels_int:, :])
     acts = t_act * s_act
     return acts
 


### PR DESCRIPTION
Training WaveGlow with PyTorch 1.0.0.dev20181122 leads to repeated deprecation warnings from `torch.nn.functional.{tanh,sigmoid}`:

```
nn.functional.tanh is deprecated. Use torch.tanh instead.
nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.
```