### PR TITLE
Upsample parameters read from data_config

### DIFF
--- a/glow.py
+++ b/glow.py
@@ -177,12 +177,12 @@ class WN(torch.nn.Module):
 
 class WaveGlow(torch.nn.Module):
     def __init__(self, n_mel_channels, n_flows, n_group, n_early_every,
-                 n_early_size, WN_config):
+                 n_early_size, WN_config, win_length, hop_length):
         super(WaveGlow, self).__init__()
 
         self.upsample = torch.nn.ConvTranspose1d(n_mel_channels,
                                                  n_mel_channels,
-                                                 1024, stride=256)
+                                                 win_length, stride=hop_length)
         assert(n_group % 2 == 0)
         self.n_flows = n_flows
         self.n_group = n_group

--- a/train.py
+++ b/train.py
@@ -154,7 +154,11 @@ if __name__ == "__main__":
     global dist_config
     dist_config = config["dist_config"]
     global waveglow_config
-    waveglow_config = config["waveglow_config"]
+    waveglow_config = { 
+        **config["waveglow_config"], 
+        'win_length': data_config['win_length'],
+        'hop_length': data_config['hop_length']
+    }
 
     num_gpus = torch.cuda.device_count()
     if num_gpus > 1:


### PR DESCRIPTION
win_length and hop_length were hard coded in https://github.com/NVIDIA/waveglow/blob/a7168f398f8e2727291c2d46d0ef35ef30956de4/glow.py#L185.