### PR TITLE
Option to continue training from the official checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,30 @@ with fused residual and skip connections.
    python3 inference.py -f mel_files.txt -w checkpoints/waveglow_10000 -o . --is_fp16 -s 0.6
    ```
 
+## Finetuning the official checkpoint with your own data
+
+The "official" checkpoint above was trained using an older version of the code.
+Therefore, you need to use `glow_old.py` to continue training from the official
+checkpoint:
+
+1. Download our [published model]
+2. Update the checkpoint to comply with recent code modifications:
+
+   `python convert_model.py waveglow_old.pt waveglow_old_updated.pt`
+
+3. Perform steps 1 and 2 from the section above
+
+4. Set `"checkpoint_path": "./waveglow_old_updated.pt"` in `config.json`
+
+5. Train your WaveGlow networks with `OLD_GLOW=1` (not yet tested with
+   `distributed.py`) 
+
+   ```command
+   mkdir checkpoints
+   OLD_GLOW=1 python train.py -c config.json
+   ```
+
+
 [//]: # (TODO)
 [//]: # (PROVIDE INSTRUCTIONS FOR DOWNLOADING LJS)
 [pytorch 1.0]: https://github.com/pytorch/pytorch#installation

--- a/glow.py
+++ b/glow.py
@@ -97,7 +97,7 @@ class Invertible1x1Conv(torch.nn.Module):
             return z
         else:
             # Forward computation
-            log_det_W = batch_size * n_of_groups * torch.logdet(W)
+            log_det_W = batch_size * n_of_groups * torch.slogdet(W)[1]
             z = self.conv(z)
             return z, log_det_W
 

--- a/train.py
+++ b/train.py
@@ -35,14 +35,27 @@ from torch.utils.data.distributed import DistributedSampler
 #=====END:   ADDED FOR DISTRIBUTED======
 
 from torch.utils.data import DataLoader
-from glow import WaveGlow, WaveGlowLoss
+if 'OLD_GLOW' in os.environ and os.environ['OLD_GLOW'] == '1':
+    print("Warning! Using old_glow.py instead of glow.py for training")
+    from glow_old import WaveGlow
+else:
+    from glow import WaveGlow
+
+from glow import WaveGlowLoss
 from mel2samp import Mel2Samp
 
 def load_checkpoint(checkpoint_path, model, optimizer):
     assert os.path.isfile(checkpoint_path)
     checkpoint_dict = torch.load(checkpoint_path, map_location='cpu')
-    iteration = checkpoint_dict['iteration']
-    optimizer.load_state_dict(checkpoint_dict['optimizer'])
+
+    if 'iteration' in checkpoint_dict:
+        iteration = checkpoint_dict['iteration']
+    else:
+        iteration = 0
+    
+    if 'optimizer' in checkpoint_dict:
+        optimizer.load_state_dict(checkpoint_dict['optimizer'])
+
     model_for_loading = checkpoint_dict['model']
     model.load_state_dict(model_for_loading.state_dict())
     print("Loaded checkpoint '{}' (iteration {})" .format(


### PR DESCRIPTION
It seems like many people are interested in continuing training from the official checkpoint (e.g. to adapt the model for their own data). As discussed in #35, this pull request adds this possibility by:

1. Implementing the `forward` method in `glow_old.py`, and
2. replacing log-determinant in `Invertible1x1Conv` with log absolute determinant

During training, `glow_old` can be used by setting the `OLD_GLOW` environment variable to 1 (see the updated `README.md`.